### PR TITLE
No default folders in mounted mock-fs's

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,10 @@ module.exports = {
                 var mockFsConfig = rewriteMockFsOptions(value[key]);
                 return {
                     mountPath: /\/$/.test(key) ? key : key + '/',
-                    fileSystem: mockfs.fs(mockFsConfig)
+                    fileSystem: mockfs.fs(mockFsConfig, {
+                        createCwd: false,
+                        createTmp: false
+                    })
                 };
             });
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "lodash": "3.9.3",
-    "mock-fs": "3.5.0",
+    "mock-fs": "3.6.0",
     "mountfs": "0.1.5"
   }
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -151,6 +151,19 @@ describe('unexpected-fs', function () {
                 return expect(files, 'to contain', 'foo.txt');
             });
         });
+        it('should list only the files specified in mocked fs when in root', function () {
+            return expect(function (cb) {
+                fs.readdir('/foo/', cb);
+            }, 'with fs mocked out', {
+                '/foo': {
+                    'foobar.txt': 'foobar'
+                }
+            }, 'to call the callback without error').spread(function (files) {
+                return expect(files, 'to satisfy', [
+                    'foobar.txt'
+                ]);
+            });
+        });
     });
 
     describe('does it update already exisitng fs modules?', function () {


### PR DESCRIPTION
For these tests to pass you have to link in the feature branch on mock-fs and make a little change adding the options argument to this function https://github.com/tschaub/mock-fs/blob/options/lib/index.js#L109 .

https://github.com/tschaub/mock-fs/pull/72

Fixes #15 
